### PR TITLE
各種バグを修正

### DIFF
--- a/server/useCase/enemyUseCase.ts
+++ b/server/useCase/enemyUseCase.ts
@@ -39,6 +39,10 @@ export const enemyUseCase = {
     return enemiesInDisplay;
   },
   kill: async (enemyId: string, userId: UserId) => {
+    const enemyStatus = await enemiesRepository.find(enemyId);
+    if (enemyStatus?.deletedAt !== null) {
+      return;
+    }
     await enemiesRepository.update(enemyId, new Date());
     const userStatus = await playersRepository.find(userId);
     if (userStatus !== null) {

--- a/server/useCase/gameUseCase.ts
+++ b/server/useCase/gameUseCase.ts
@@ -41,6 +41,10 @@ export const gameUseCase = {
     return player;
   },
   collision: async (player: PlayerModel, enemy: EnemyModel) => {
+    const enemyStatus = await enemiesRepository.find(enemy.id);
+    if (enemyStatus?.deletedAt !== null) {
+      return;
+    }
     const newPlayer = { ...player, health: player.health - 1 };
     await playersRepository.save(newPlayer);
     await enemiesRepository.update(enemy.id, new Date());

--- a/server/useCase/gameUseCase.ts
+++ b/server/useCase/gameUseCase.ts
@@ -45,7 +45,13 @@ export const gameUseCase = {
     if (enemyStatus?.deletedAt !== null) {
       return;
     }
-    const newPlayer = { ...player, health: player.health - 1 };
+    let newPlayer;
+    if (player.health <= 0) {
+      const newScore = player.score - 5 >= 0 ? player.score - 5 : 0; // 仮でスコアが0以下にならないように
+      newPlayer = { ...player, health: 0, score: newScore };
+    } else {
+      newPlayer = { ...player, health: player.health - 1 };
+    }
     await playersRepository.save(newPlayer);
     await enemiesRepository.update(enemy.id, new Date());
   },


### PR DESCRIPTION
フロントから同じ敵に二回deleteが送られてもスコアが１点しか増えないように
フロントから同じ敵に二回deleteが送られても体力が１しか減らないように
体力が0以下の場合スコアを５点減らす
スコアが０点以下の場合０点のままに(これはエラー回避の仮で後からゲームオーバーなどにしてもよい)